### PR TITLE
Adds a thread (chapter 3.4.5)

### DIFF
--- a/Kapitel 3/3.4.5/binding-valueAt/src/main/java/de/javafxbuch/ValueAtBinding.java
+++ b/Kapitel 3/3.4.5/binding-valueAt/src/main/java/de/javafxbuch/ValueAtBinding.java
@@ -39,6 +39,21 @@ public class ValueAtBinding extends Application {
         primaryStage.setScene(scene);
         System.out.println("You have been Rick rolled!");
         primaryStage.show();
+
+        Thread t = new Thread(()->{
+        	while(true) {
+        		try {
+					Thread.sleep(1000);
+				} catch (InterruptedException e) {
+					// ignored intentionally
+				}
+        		for(String key: observableMap.keySet()) {
+        			observableMap.put(key, observableMap.get(key)*1.1);
+        		}
+        	}
+        	
+        });
+        t.start();
     }
 
     /**


### PR DESCRIPTION
In this example you demonstrate how a property can be bound to an
element in a ObservableMap. However, the data in the map does not
change, and this is what this PR does, i.e. a thread is started
which increases each sec the values by 10%.

This is a change in a part of the code which is not contained in the
book.