### PR TITLE
Sets initial value according to initial label (chapter 4.2.3)

### DIFF
--- a/Kapitel 4/4.2.3/controls-checkbox/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 4/4.2.3/controls-checkbox/src/main/java/de/javafxbuch/MainApp.java
@@ -17,6 +17,7 @@ public class MainApp extends Application {
 
         CheckBox checkBox = new CheckBox("I'm undecided");
         checkBox.setAllowIndeterminate(true);
+        checkBox.setIndeterminate(false);
         checkBox.setOnAction(e -> {
             if (checkBox.isIndeterminate()) {
                 checkBox.setText("I'm undecided");


### PR DESCRIPTION
If the appliation is started, then the checkbox displays the text "I'm
undecided", although the checkbox is deselected. So either the initial
text should be changed to "I disagree" or (what this commit does) the
initial state should be changed to indeterminate.