### PR TITLE
Change the Editable double ListCell-Implementation (chapter 4.2.7)

### DIFF
--- a/Kapitel 4/4.2.7/controls-listview-cell-simple/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 4/4.2.7/controls-listview-cell-simple/src/main/java/de/javafxbuch/MainApp.java
@@ -49,19 +49,8 @@ public class MainApp extends Application {
             }
         }
 
-        @Override
-        public void replaceSelection(String text) {
-            final int dot = getCaretPosition();
-            final int mark = getAnchor();
-            int start = Math.min(dot, mark);
-            int end = Math.max(dot, mark);
-            if (validate(createPreview(start, end, text))) {
-                super.replaceSelection(text);
-            }
-        }
-
         private boolean validate(String text) {
-            if (text.matches("[-+]?[0-9]*\\.?[0-9]+") || text == "") {
+            if (text.matches("[-+]?[0-9]*\\.?[0-9]*") || text == "") {
                 System.out.println("ok");
                 return true;
             }
@@ -84,18 +73,13 @@ public class MainApp extends Application {
         DoubleTextField dtf = new DoubleTextField();
 
         public DoubleListCell() {
-            dtf.setOnAction(new EventHandler<ActionEvent>() {
-                @Override
-                public void handle(ActionEvent event) {
-                    commitEdit(Double.parseDouble(dtf.getText()));
-                }
-            });
+            dtf.setOnAction(e -> commitEdit(Double.parseDouble(dtf.getText())));
         }
 
         @Override
         protected void updateItem(Double item, boolean empty) {
             super.updateItem(item, empty);
-            if (item != null & !empty) {
+            if (item != null && !empty) {
                 dtf.setText(item.toString());
                 if (!isEditing()) {
                     setText(item.toString());

--- a/Kapitel 4/4.2.7/controls-listview-cell-simple/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 4/4.2.7/controls-listview-cell-simple/src/main/java/de/javafxbuch/MainApp.java
@@ -1,8 +1,6 @@
 package de.javafxbuch;
 
 import javafx.application.Application;
-import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.geometry.Orientation;
 import javafx.scene.Scene;
 import javafx.scene.control.ListCell;


### PR DESCRIPTION
- removes method replaceSelection
- changes the regex for doulbes (allows trailing decimal points)
- changes the anonymous inner class in the DoubleListCell ctor to a  lambda
- Removes two imports that are no longer necessary due to these changes
- replaces bitset-and & with a logical and &&
