### PR TITLE
Changes Card-Stack-Layout (chapter 5)

### DIFF
--- a/Kapitel 5/5.10/tweetalot/src/main/java/de/javafxbuch/HomeTimeline.java
+++ b/Kapitel 5/5.10/tweetalot/src/main/java/de/javafxbuch/HomeTimeline.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package de.javafxbuch;
 
 import javafx.collections.ObservableList;

--- a/Kapitel 5/5.3/layout-anchorpane/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 5/5.3/layout-anchorpane/src/main/java/de/javafxbuch/MainApp.java
@@ -5,7 +5,6 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
 public class MainApp extends Application {
@@ -26,7 +25,7 @@ public class MainApp extends Application {
         anchorPane.getChildren().add(buttons);
         AnchorPane.setRightAnchor(buttons, 10.0);
         AnchorPane.setBottomAnchor(buttons, 20.0);
-        primaryStage.setScene(new Scene(new StackPane(anchorPane), 300, 200));
+        primaryStage.setScene(new Scene(anchorPane, 300, 200));
 
         primaryStage.show();
     }

--- a/Kapitel 5/5.4/layout-flowpane/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 5/5.4/layout-flowpane/src/main/java/de/javafxbuch/MainApp.java
@@ -5,7 +5,6 @@ import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.FlowPane;
-import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
 public class MainApp extends Application {
@@ -27,7 +26,7 @@ public class MainApp extends Application {
         for (int i = 0; i < images.length; i++) {
             iconView.getChildren().add(new ImageView(images[i]));
         }
-        primaryStage.setScene(new Scene(new StackPane(iconView), 300, 200));
+        primaryStage.setScene(new Scene(iconView, 300, 200));
 
         primaryStage.show();
     }

--- a/Kapitel 5/5.9/layout-custom/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 5/5.9/layout-custom/src/main/java/de/javafxbuch/MainApp.java
@@ -32,6 +32,8 @@ public class MainApp extends Application {
         EventHandler<MouseEvent> clickHandler;
         final CardStackLayout cardStackLayout = new CardStackLayout();
         final CardStackLayout cardStackLayout2 = new CardStackLayout();
+        cardStackLayout.setMinHeight(200);
+        cardStackLayout2.setMinHeight(200);
         clickHandler = new EventHandler<MouseEvent>() {
 
             @Override


### PR DESCRIPTION
Adds the invocation of
   cardStackLayout.setMinHeight(200);
to the top card stack otherwise the first row disappears if all cards have been moved to the second row (for symmetry reasons this min height is set on both cardStackLayout instances).

Moreover, instead of passing
    new StackPane(iconView)
    new StackPane(anchorPane)
to the new scene, you could also simply pass the
    iconView
    anchorPane
to the scene.

Ok, the StackPane would allow to add additional controls, but this is not used here.