### PR TITLE
Removes ""+ as next argument is already of type String (chapter 6)

### DIFF
--- a/Kapitel 6/6.9/fxml-calculator/src/main/java/de/javafxbuch/CalculatorController.java
+++ b/Kapitel 6/6.9/fxml-calculator/src/main/java/de/javafxbuch/CalculatorController.java
@@ -68,7 +68,7 @@ public class CalculatorController implements Initializable {
             try {
                 Number parse = NumberFormat.getInstance(Locale.US).parse(displayedtext.get());
                 double res = parse.doubleValue() * -1;
-                displayedtext.set("" + NumberFormat.getInstance(Locale.US).format(res));
+                displayedtext.set(NumberFormat.getInstance(Locale.US).format(res));
             } catch (ParseException ex) {
                 Logger.getLogger(CalculatorController.class.getName()).log(Level.SEVERE, null, ex);
             }


### PR DESCRIPTION
NumberFormat.getInstance(Locale.US).format(res) returns a String, so
concatenating it with "" is not necessary.