### PR TITLE
Changes pseudo.css (chapter 7)

### DIFF
--- a/Kapitel 7/7.1/fxml-calculator-css/src/main/resources/de/javafxbuch/calculator.css
+++ b/Kapitel 7/7.1/fxml-calculator-css/src/main/resources/de/javafxbuch/calculator.css
@@ -6,7 +6,7 @@ GridPane{
     -fx-background-color: white;
     -fx-alignment: CENTER_RIGHT;
     -fx-font-size: 50;
-    -fx-padding: 4 4 4 4;
+    -fx-padding: 4 4 0 4;
 }
 
 .button{

--- a/Kapitel 7/7.2/css-pseudoclass/src/main/resources/de/javafxbuch/pseudo.css
+++ b/Kapitel 7/7.2/css-pseudoclass/src/main/resources/de/javafxbuch/pseudo.css
@@ -1,5 +1,4 @@
-CustomRegion:active{
+.my:active{
     -fx-background-color: red;
     -fx-opacity: 1;
 }
-


### PR DESCRIPTION
The code defines the used customRegion to be of type "my", therefore this type should be used in the css file, otherwise, the line
        customRegion.getStyleClass().add("my");
could be deleted.

As an alternative, both declarations could be shown by defining

   .my:active{
       -fx-background-color: red;
       -fx-opacity: 1;
   }

   CustomRegion:active{
       -fx-background-color: blue;
       -fx-opacity: 1;
   }

If the "my" style is not assigned, then the color would be set to blue.