### PR TITLE
Bug fixes in chapter 9

### DIFF
--- a/Kapitel 9/9.3.2/progressindicator/src/main/java/de/javafxbuch/CounterTask.java
+++ b/Kapitel 9/9.3.2/progressindicator/src/main/java/de/javafxbuch/CounterTask.java
@@ -18,7 +18,7 @@ public class CounterTask extends Task<Integer> {
             Thread.sleep(10);
             updateProgress(i, max);
         }
-
+		updateProgress(max, max);
 
         updateMessage("READY");
         return max;

--- a/Kapitel 9/9.4/tweetalot/src/main/java/de/javafxbuch/HomeTimeline.java
+++ b/Kapitel 9/9.4/tweetalot/src/main/java/de/javafxbuch/HomeTimeline.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package de.javafxbuch;
 
 import javafx.collections.ObservableList;
@@ -20,12 +15,13 @@ import twitter4j.TwitterFactory;
 public class HomeTimeline extends ScrollPane {
     
     private TimelineView timelineView;
+    private final RefreshService refreshService;
     
     public HomeTimeline() {
         setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
         setVbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
         setFitToWidth(true);
-        RefreshService refreshService = new RefreshService();
+        refreshService = new RefreshService();
         refreshService.setPeriod(Duration.minutes(2));
         refreshService.setRestartOnFailure(true);
         refreshService.setMaximumFailureCount(3);
@@ -42,7 +38,6 @@ public class HomeTimeline extends ScrollPane {
     }
     
     public void refresh() throws TwitterException {
-        
         Twitter twitter = TwitterFactory.getSingleton();
         ResponseList<Status> homeTimeline = twitter.getHomeTimeline();
         ObservableTimelineList observableTimelineList = new ObservableTimelineList(homeTimeline);

--- a/Kapitel 9/9.4/tweetalot/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 9/9.4/tweetalot/src/main/java/de/javafxbuch/MainApp.java
@@ -27,7 +27,6 @@ public class MainApp extends Application {
         button.setFont(Font.font("FontAwesome", 40));
         BorderPane root = new BorderPane();
         final HomeTimeline homeTimeline = new HomeTimeline();
-//        homeTimeline.refresh();
         root.setCenter(homeTimeline);
         ToolBar toolBar = new ToolBar();
         toolBar.setOrientation(Orientation.VERTICAL);

--- a/Kapitel 9/9.4/tweetalot/src/main/java/de/javafxbuch/RefreshService.java
+++ b/Kapitel 9/9.4/tweetalot/src/main/java/de/javafxbuch/RefreshService.java
@@ -3,11 +3,10 @@ package de.javafxbuch;
 import javafx.concurrent.ScheduledService;
 import javafx.concurrent.Task;
 
-public class RefreshService
-        extends ScheduledService<ObservableTimelineList> {
+public class RefreshService extends ScheduledService<ObservableTimelineList> {
 
-    @Override
-    protected Task<ObservableTimelineList> createTask() {
-        return new RefreshTask();
-    }
+	@Override
+	protected Task<ObservableTimelineList> createTask() {
+		return new RefreshTask();
+	}
 }


### PR DESCRIPTION
**Updates the progress indicator to be finished**
By invoking
        
        updateProgress(max, max);

the properties are informed that the task is completed.
[this should probably be added to the former projects as well.]

**Fixes a bug in tweetalot (chap 9.4)**
In the original version the `RefreshService `was declared as a local variable in the constructor and was reclaimed by the GC after creation of the timeline.

The call `homeTimeline.refresh()` declared in the `MainApp `is no longer needed (was commented out). Without that code the timeline was not initialized.
