### PR TITLE
Bug fixes in chapter 13

### DIFF
--- a/Kapitel 13/13.1/webview-hello/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 13/13.1/webview-hello/src/main/java/de/javafxbuch/MainApp.java
@@ -1,5 +1,7 @@
 package de.javafxbuch;
 
+import java.util.ArrayList;
+
 import javafx.application.Application;
 import javafx.collections.ListChangeListener;
 import javafx.concurrent.Worker.State;
@@ -47,7 +49,7 @@ public class MainApp extends Application {
                 (ListChangeListener.Change<? extends Entry> c) -> {
                     c.next();
                     for (Entry e : c.getAddedSubList()) {
-                        for (MenuItem i : historyMenu.getItems()) {
+                        for (MenuItem i : new ArrayList<>(historyMenu.getItems())) {
                             if (i.getId().equals(e.getUrl())) {
                                 historyMenu.getItems().remove(i);
                             }

--- a/Kapitel 13/13.1/webview-hello/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 13/13.1/webview-hello/src/main/java/de/javafxbuch/MainApp.java
@@ -42,7 +42,6 @@ public class MainApp extends Application {
         MenuItem home = new MenuItem("Home");
         navigateMenu.getItems().addAll(home);
         home.setOnAction(e -> engine.load("http://eppleton.de"));
-        menuBar.getMenus().add(navigateMenu);
         Menu historyMenu = new Menu("History");
         engine.getHistory().getEntries().addListener(
                 (ListChangeListener.Change<? extends Entry> c) -> {

--- a/Kapitel 4/4.2.9/controls-treeview/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 4/4.2.9/controls-treeview/src/main/java/de/javafxbuch/MainApp.java
@@ -49,11 +49,10 @@ public class MainApp extends Application {
                 .add(new TreeItem<Color>(Color.BLUE));
         StackPane pane = new StackPane(treeView);
         Scene scene = new Scene(pane, 300, 250);
+        scene.getStylesheets().add(getClass().getResource("tree.css").toExternalForm());
 
-        primaryStage.setTitle(
-                "TableView Demo");
+		primaryStage.setTitle("TableView Demo");
         primaryStage.setScene(scene);
-
         primaryStage.show();
     }
 

--- a/Kapitel 4/4.2.9/controls-treeview/src/main/resources/de/javafxbuch/tree.css
+++ b/Kapitel 4/4.2.9/controls-treeview/src/main/resources/de/javafxbuch/tree.css
@@ -1,0 +1,7 @@
+.tree-cell > .tree-disclosure-node > .arrow {
+    -fx-rotate: 0;
+}
+
+.tree-cell:expanded > .tree-disclosure-node > .arrow {
+    -fx-rotate: 90;
+}


### PR DESCRIPTION
**Fixes the treeview expand/collapse arrow bug**
This commit fixes the treeview expand/collapse arrow bug as described in
https://stackoverflow.com/questions/50011276/javafx-treeview-expand-collapse-disclosure-arrow-bug

It adds a style file (`tree.css`) which defines the rotation angle of the arrow for both the normal and the expanded case.

**Removes doubled navigate menu**
Removes

        menuBar.getMenus().add(navigateMenu);
as the menu is also added with the command

        menuBar.getMenus().addAll(navigateMenu, historyMenu);

It appeared twice.

**Fixes the CME exception**
When an entry is removed from list historyMenu.getItems() in the loop

       for (MenuItem i : historyMenu.getItems()) {
            if (i.getId().equals(e.getUrl())) {
                historyMenu.getItems().remove(i);
            }
       }
then a CME is thrown. Iterating over a copy fixes this problem. An alternative would be to leave the loop with a break, but this only works if the menu item `i` appears at most once in the list.