### PR TITLE
Fixes the treeview expand/collapse arrow bug (chapter 4)

### DIFF
--- a/Kapitel 4/4.2.9/controls-treeview/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 4/4.2.9/controls-treeview/src/main/java/de/javafxbuch/MainApp.java
@@ -49,11 +49,10 @@ public class MainApp extends Application {
                 .add(new TreeItem<Color>(Color.BLUE));
         StackPane pane = new StackPane(treeView);
         Scene scene = new Scene(pane, 300, 250);
+        scene.getStylesheets().add(getClass().getResource("tree.css").toExternalForm());
 
-        primaryStage.setTitle(
-                "TableView Demo");
+		primaryStage.setTitle("TableView Demo");
         primaryStage.setScene(scene);
-
         primaryStage.show();
     }
 

--- a/Kapitel 4/4.2.9/controls-treeview/src/main/resources/de/javafxbuch/tree.css
+++ b/Kapitel 4/4.2.9/controls-treeview/src/main/resources/de/javafxbuch/tree.css
@@ -1,0 +1,7 @@
+.tree-cell > .tree-disclosure-node > .arrow {
+    -fx-rotate: 0;
+}
+
+.tree-cell:expanded > .tree-disclosure-node > .arrow {
+    -fx-rotate: 90;
+}


### PR DESCRIPTION
This commit fixes the treeview expand/collapse arrow bug as described in
https://stackoverflow.com/questions/50011276/javafx-treeview-expand-collapse-disclosure-arrow-bug

It adds a style file (tree.css) which defines the rotation angle of the arrow for both the normal and the expanded case.