### PR TITLE
Removes final declarations

### DIFF
--- a/Kapitel 4/4.2.4.1/controls-textarea/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 4/4.2.4.1/controls-textarea/src/main/java/de/javafxbuch/MainApp.java
@@ -15,7 +15,7 @@ public class MainApp extends Application {
 
     @Override
     public void start(Stage primaryStage) {
-        final TextArea textArea = new TextArea();
+        TextArea textArea = new TextArea();
         textArea.setPrefRowCount(10);
         textArea.setPrefColumnCount(20);
         textArea.setWrapText(true);

--- a/Kapitel 4/4.2.6/controls-contextmenu/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 4/4.2.6/controls-contextmenu/src/main/java/de/javafxbuch/MainApp.java
@@ -31,7 +31,7 @@ public class MainApp extends Application {
         root.setTop(menuBar);
         ImageView imageView = new ImageView(new Image(getClass().getResource("javaduke_html5.png").toExternalForm()));
         root.setCenter(imageView);
-        final ContextMenu contextMenu = new ContextMenu();
+        ContextMenu contextMenu = new ContextMenu();
         MenuItem halloMenuItem = new MenuItem("Sag 'Hallo'");
         halloMenuItem.setOnAction(
                 e -> System.out.println("Duke: 'Hallo!'"));

--- a/Kapitel 4/4.3.4/controls-splitpane-resize/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 4/4.3.4/controls-splitpane-resize/src/main/java/de/javafxbuch/MainApp.java
@@ -16,11 +16,11 @@ public class MainApp extends Application {
     @Override
     public void start(Stage primaryStage) {
         SplitPane splitPane = new SplitPane();
-        final StackPane stackPane = new StackPane(new Label("Hilfsfenster1"));
+        StackPane stackPane = new StackPane(new Label("Hilfsfenster1"));
         SplitPane.setResizableWithParent(stackPane, false);
         splitPane.getItems().add(stackPane);
         splitPane.getItems().add(new StackPane(new Label("Dokumentenfenster")));
-        final StackPane stackPane1 = new StackPane(new Label("Hilfsfenster2"));
+        StackPane stackPane1 = new StackPane(new Label("Hilfsfenster2"));
         SplitPane.setResizableWithParent(stackPane1, false);
         splitPane.getItems().add(stackPane1);
         StackPane pane = new StackPane(splitPane);

--- a/Kapitel 5/5.10/tweetalot/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 5/5.10/tweetalot/src/main/java/de/javafxbuch/MainApp.java
@@ -35,7 +35,7 @@ public class MainApp extends Application {
         Button button = new Button("\uf015");
         button.setFont(Font.font("FontAwesome", 40));
         BorderPane root = new BorderPane();
-        final HomeTimeline homeTimeline = new HomeTimeline();
+        HomeTimeline homeTimeline = new HomeTimeline();
         homeTimeline.refresh();
         root.setCenter(homeTimeline);
         ToolBar toolBar = new ToolBar();

--- a/Kapitel 5/5.10/tweetalot/src/main/java/de/javafxbuch/StatusView.java
+++ b/Kapitel 5/5.10/tweetalot/src/main/java/de/javafxbuch/StatusView.java
@@ -20,7 +20,7 @@ public class StatusView extends HBox {
     private final VBox textBox;
     private final Label screenName;
     private final Label statusText;
-    private VBox toolbar;
+    private final VBox toolbar;
 
     public StatusView() {
         setPadding(new Insets(4));

--- a/Kapitel 5/5.9/layout-custom/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 5/5.9/layout-custom/src/main/java/de/javafxbuch/MainApp.java
@@ -30,8 +30,8 @@ public class MainApp extends Application {
         String[] values = {"2", "3", "4", "5", "6", "7", "8", "9", "10", "ace", "jack", "king", "queen"};
         String[] colors = {"clubs", "diamonds", "hearts", "spades"};
         EventHandler<MouseEvent> clickHandler;
-        final CardStackLayout cardStackLayout = new CardStackLayout();
-        final CardStackLayout cardStackLayout2 = new CardStackLayout();
+        CardStackLayout cardStackLayout = new CardStackLayout();
+        CardStackLayout cardStackLayout2 = new CardStackLayout();
         clickHandler = new EventHandler<MouseEvent>() {
 
             @Override

--- a/Kapitel 9/9.2.2/task-simple/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 9/9.2.2/task-simple/src/main/java/de/javafxbuch/MainApp.java
@@ -22,7 +22,7 @@ public class MainApp extends Application {
     public void start(Stage primaryStage) {
         Button btn = new Button();
         btn.setText("Run");
-        final Task<Integer> task = new Task<Integer>() {
+        Task<Integer> task = new Task<Integer>() {
             @Override
             protected Integer call() throws Exception {
                 int iterationen;

--- a/Kapitel 9/9.4/tweetalot/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 9/9.4/tweetalot/src/main/java/de/javafxbuch/MainApp.java
@@ -26,7 +26,7 @@ public class MainApp extends Application {
         button.getStyleClass().add("view-button");
         button.setFont(Font.font("FontAwesome", 40));
         BorderPane root = new BorderPane();
-        final HomeTimeline homeTimeline = new HomeTimeline();
+        HomeTimeline homeTimeline = new HomeTimeline();
 //        homeTimeline.refresh();
         root.setCenter(homeTimeline);
         ToolBar toolBar = new ToolBar();

--- a/Kapitel 9/9.4/tweetalot/src/main/java/de/javafxbuch/StatusView.java
+++ b/Kapitel 9/9.4/tweetalot/src/main/java/de/javafxbuch/StatusView.java
@@ -20,7 +20,7 @@ public class StatusView extends HBox {
     private final VBox textBox;
     private final Label screenName;
     private final Label statusText;
-    private VBox toolbar;
+    private final VBox toolbar;
 
     public StatusView() {
         setPadding(new Insets(4));


### PR DESCRIPTION
In some classes, local variables are declared as final, but (as you know) it is no longer necessary to declare local variables which are used in anonymous classes as final. The compiler can infer the final property automatically. I assume that you have converted some anonymous classes to lambda expressions, and in this case I would drop the final modifier from locals. 

The commits contained in this PR remove some of these final declarations.

For fields however, the final modifier is useful (JMM => initialization) so at least at one place I have added a final modifier.
