### PR TITLE
Generics cleanup

### DIFF
--- a/Kapitel 4/4.2.10/controls-choicebox/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 4/4.2.10/controls-choicebox/src/main/java/de/javafxbuch/MainApp.java
@@ -14,7 +14,7 @@ public class MainApp extends Application {
 
     @Override
     public void start(Stage primaryStage) {
-        ChoiceBox cb = new ChoiceBox();
+        ChoiceBox<String> cb = new ChoiceBox<>();
         for (int i = 0; i < 20; i++) {
             cb.getItems().add("Option " + i);
         }

--- a/Kapitel 4/4.2.8/controls-tableview/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 4/4.2.8/controls-tableview/src/main/java/de/javafxbuch/MainApp.java
@@ -24,10 +24,11 @@ public class MainApp extends Application {
         launch(args);
     }
 
-    @Override
+    @SuppressWarnings("unchecked")
+	@Override
     public void start(Stage primaryStage) {
-        TableView tableView = new TableView();
-        ObservableList< Player> players = FXCollections
+        TableView<Player> tableView = new TableView<>();
+        ObservableList<Player> players = FXCollections
                 .observableArrayList(
                         new Player("Manuel", "Neuer", 0),
                         new Player("Philipp", "Lahm", 0),
@@ -36,9 +37,9 @@ public class MainApp extends Application {
                         new Player("Benedikt", "Höwedes", 0)
                 );
         tableView.setItems(players);
-        TableColumn firstName = new TableColumn("Vorname");
-        TableColumn lastName = new TableColumn("Nachname");
-        TableColumn goals = new TableColumn("Tore");
+        TableColumn<Player, String> firstName = new TableColumn<>("Vorname");
+        TableColumn<Player, String> lastName = new TableColumn<>("Nachname");
+        TableColumn<Player, Integer> goals = new TableColumn<>("Tore");
         tableView.getColumns().addAll(firstName, lastName, goals);
         firstName.setCellValueFactory(
                 new PropertyValueFactory<Player, String>("firstName")
@@ -46,7 +47,7 @@ public class MainApp extends Application {
         lastName.setCellValueFactory(
                 new PropertyValueFactory<Player, String>("lastName"));
         goals.setCellValueFactory(
-                new PropertyValueFactory< Player, Integer>("goals")
+                new PropertyValueFactory<Player, Integer>("goals")
         );
         goals.setCellFactory(new Callback<TableColumn< Player, Integer>, TableCell<Player, Integer>>() {
             @Override

--- a/Kapitel 4/4.2.8/controls-tableview/src/main/java/de/javafxbuch/MainApp.java
+++ b/Kapitel 4/4.2.8/controls-tableview/src/main/java/de/javafxbuch/MainApp.java
@@ -45,13 +45,14 @@ public class MainApp extends Application {
                 new PropertyValueFactory<Player, String>("firstName")
         );
         lastName.setCellValueFactory(
-                new PropertyValueFactory<Player, String>("lastName"));
+                new PropertyValueFactory<Player, String>("lastName")
+        );
         goals.setCellValueFactory(
                 new PropertyValueFactory<Player, Integer>("goals")
         );
-        goals.setCellFactory(new Callback<TableColumn< Player, Integer>, TableCell<Player, Integer>>() {
+        goals.setCellFactory(new Callback<TableColumn<Player, Integer>, TableCell<Player, Integer>>() {
             @Override
-            public TableCell< Player, Integer> call(TableColumn< Player, Integer> param) {
+            public TableCell<Player, Integer> call(TableColumn<Player, Integer> param) {
                 return new GoalsCell();
             }
         });
@@ -61,7 +62,7 @@ public class MainApp extends Application {
         firstName.setOnEditCommit(new EventHandler<CellEditEvent<Player, String>>() {
             @Override
             public void handle(CellEditEvent<Player, String> t) {
-                ((Player) t.getTableView().getItems().get(t.getTablePosition().getRow())).setFirstName(t.getNewValue());
+                t.getTableView().getItems().get(t.getTablePosition().getRow()).setFirstName(t.getNewValue());
             }
         });
         StackPane root = new StackPane(tableView);


### PR DESCRIPTION
This PR adds generic declarations at some places (instead of the use of raw types). This may simplify the code (as casts can be dropped).

However, at one place this change leads to the warning "A generic array of TableColumn<Player,?> is
created for a varargs" and therefore I added a suppress warnings annotation, but I have seen in later projects that you have this problem in other classes as well and you have not added an ignore warnings annotation, so the one I have added could be removed.